### PR TITLE
Add z-index to action-modal-overlay class

### DIFF
--- a/frontend/src/ActionModal/components/ActionModal.vue
+++ b/frontend/src/ActionModal/components/ActionModal.vue
@@ -763,6 +763,7 @@ export default {
   height: 100vh;
   background: black;
   opacity: 0.5;
+  z-index: 1;
 }
 
 .action-modal {


### PR DESCRIPTION
Add z-index to .action-modal-overlay class to prevent other components from being on top of the overlay when action is executed