### PR TITLE
Commission(s) -> Commission -96px -> 150px

### DIFF
--- a/frontend/src/components/staking/PageValidators/TableValidators.vue
+++ b/frontend/src/components/staking/PageValidators/TableValidators.vue
@@ -159,10 +159,10 @@ export default {
           render: value => zeroDecimals(ones(value))
         },
         {
-          title: `Commissions`,
+          title: `Commission`,
           value: `rate`,
           tooltip: tooltips.v_list.fees,
-          width: "96px",
+          width: "150px",
           align: "right",
           render: value => percent(value) // render as function - do format value here
         },


### PR DESCRIPTION
Commissions should be singular and the Word is cut off at 96px.. 150px is appropriate

Currently @ 96px and with the extra 's' on the end:

![image](https://user-images.githubusercontent.com/26277199/135591815-689ed999-5306-43d2-9611-efe399f9526c.png)

Remove 's' and make `width: 150px`

![image](https://user-images.githubusercontent.com/26277199/135592080-3df38aa4-cd4a-4bda-84cc-da583ae0d4a7.png)

