### PR TITLE
fix: redudant tooltip "show on ledger"

### DIFF
--- a/frontend/src/components/common/Bech32.vue
+++ b/frontend/src/components/common/Bech32.vue
@@ -14,10 +14,6 @@
 
     <div
       class="show-on-ledger"
-      v-tooltip="{
-        placement: 'top',
-        content: ledgerSuccess || `Click to show on Ledger`
-      }"
     >
       <a
         v-if="session && !session.isMobile && session.sessionType === 'ledger'"


### PR DESCRIPTION
The "Click to show on Ledger" tooltip is redundant and therefore should be removed.

![image](https://user-images.githubusercontent.com/11234273/139506758-049ed9ed-fc3f-4d5d-b098-9f2f87cf40ca.png)
