### PR TITLE
[UPD] HIP-20: Adding Decimal To The Staking Dashboard

### DIFF
--- a/frontend/src/components/staking/TableDelegations/TableDelegations.vue
+++ b/frontend/src/components/staking/TableDelegations/TableDelegations.vue
@@ -122,7 +122,7 @@ export default {
             tooltip: tooltips.portfolio.reward_up_to_date,
             width: "200px",
             align: "right",
-            render: value => zeroDecimals(ones(value)) + " ONE"
+            render: value => ones(value).toFixed(3) + " ONE" 
           },
           {
             title: `Expected Return`,

--- a/frontend/src/components/staking/TableDelegations/TableDelegations.vue
+++ b/frontend/src/components/staking/TableDelegations/TableDelegations.vue
@@ -122,7 +122,7 @@ export default {
             tooltip: tooltips.portfolio.reward_up_to_date,
             width: "200px",
             align: "right",
-            render: value => ones(value).toFixed(3) + " ONE" 
+            render: value => parseFloat(ones(value).toFixed(3)) + " ONE" 
           },
           {
             title: `Expected Return`,

--- a/frontend/src/components/wallet/TmBalance.vue
+++ b/frontend/src/components/wallet/TmBalance.vue
@@ -29,7 +29,7 @@
           <h3 v-info-style v-tooltip.top="tooltips.portfolio.rewards">
             Rewards
           </h3>
-          <h2>+{{ ones(rewards()).toFixed(3) }}</h2>
+          <h2>+{{ parseFloat(ones(rewards()).toFixed(3)) }}</h2>
         </div>
       </div>
       <div class="total-atoms total-undel" v-if="totalUndelegated">

--- a/frontend/src/components/wallet/TmBalance.vue
+++ b/frontend/src/components/wallet/TmBalance.vue
@@ -29,7 +29,7 @@
           <h3 v-info-style v-tooltip.top="tooltips.portfolio.rewards">
             Rewards
           </h3>
-          <h2>+{{ rewards | ones | zeroDecimals }}</h2>
+          <h2>+{{ ones(rewards()).toFixed(3) }}</h2>
         </div>
       </div>
       <div class="total-atoms total-undel" v-if="totalUndelegated">


### PR DESCRIPTION
Implementation of the following HIP Proposal to the staking dashboard.

Add 3 decimal places to the Staking Dashboard and Overview as detailed below.

🚨 Validator DAO Vote 🚨

HIP-20 Adding Decimal To The Staking Dashboard

🗓️ Start: Nov 26, 2021
🗓️ End:   Dec 10, 2021 

✍️Talk: talk.harmony.one/t/hip-20-adding-decimal-to-the-staking-dashboard/5674
🗳️Vote: gov.harmony.one/#/dao-mainnet/proposal/QmTzqwz6acqpEExRgSZ49dVa5516sFEJ4iSHJeJ8Xnf3yT

💙#VDaoDotOne💙 @harmonyprotocol $ONE  