### PR TITLE
Only cache logos for validators that are set to active

### DIFF
--- a/appengine/src/services/sync/validators-avatars.ts
+++ b/appengine/src/services/sync/validators-avatars.ts
@@ -40,7 +40,7 @@ export class ValidatorsAvatarCacheService {
 
     loop = async () => {
         try {
-            const validators = Object.values(this.cache.VALIDATORS) as any
+            const validators = (Object.values(this.cache.VALIDATORS) as any).filter(x => x.active)
 
             // console.log(`Caching validators' avatars start`)
             const now = Date.now()


### PR DESCRIPTION
There are over 700 validators in the validator list, this causes extreme lag in pulling logos/avatars for validators. Validators that have their active flag set to true, should be the only one's we're pulling logos for, this will help tremendously with validators complaining their logos aren't showing up. It's not a permanaent fix for this, as I believe this module needs to be re-written but it's better than the current state