### PR TITLE
Fix modal on mobile, fix metamask mobile claiming

### DIFF
--- a/frontend/src/ActionModal/components/ActionModal.vue
+++ b/frontend/src/ActionModal/components/ActionModal.vue
@@ -625,6 +625,7 @@ export default {
         this.session.browserWithLedgerSupport ||
         this.session.selectedSignMethod === "onewallet" ||
         this.session.selectedSignMethod === "mathwallet" ||
+        this.session.sessionType === 'metamask' ||
         (this.selectedSignMethod === "extension" &&
           this.modalContext.isExtensionAccount)
       )
@@ -1043,11 +1044,11 @@ export default {
 }
 
 .action-modal {
-  position: fixed;
-  top: calc(50vh - 250px);
-  right: calc(50vw - 250px);
-  width: 100%;
-  width: 500px;
+  position: absolute;
+  left: 50%;
+  right: 50%;
+  transform: translate(-50%, -50%);
+  width: 90%;
   max-width: 500px;
   height: auto;
   max-height: 600px;


### PR DESCRIPTION
Fixes modal from overflowing off screen and fixes Metamask claiming, where button was disabled if using Metamask mobile due to returning 'undefined' value when retrieving hasSigningMethod() causing buton to be disabled.