### PR TITLE
Reduce excessive Metamask gasLimit

### DIFF
--- a/frontend/src/ActionModal/components/ActionModal.vue
+++ b/frontend/src/ActionModal/components/ActionModal.vue
@@ -625,6 +625,7 @@ export default {
         this.session.browserWithLedgerSupport ||
         this.session.selectedSignMethod === "onewallet" ||
         this.session.selectedSignMethod === "mathwallet" ||
+        this.session.sessionType === 'metamask' ||
         (this.selectedSignMethod === "extension" &&
           this.modalContext.isExtensionAccount)
       )
@@ -1043,11 +1044,11 @@ export default {
 }
 
 .action-modal {
-  position: fixed;
-  top: calc(50vh - 250px);
-  right: calc(50vw - 250px);
-  width: 100%;
-  width: 500px;
+  position: absolute;
+  left: 50%;
+  right: 50%;
+  transform: translate(-50%, -50%);
+  width: 90%;
   max-width: 500px;
   height: auto;
   max-height: 600px;

--- a/frontend/src/scripts/metamask-utils/index.js
+++ b/frontend/src/scripts/metamask-utils/index.js
@@ -41,7 +41,7 @@ export const processMetaMaskMessage = async (
     let result;
     let error;
 
-    const gas = 6721900;
+    const gas = 100000;
     const gasPrice = Math.max(new BN(await hmyWeb3.eth.getGasPrice()).mul(new BN(1)).toNumber(), gasPriceData);
 
     try {


### PR DESCRIPTION
Metamask gasLimit is set to an outrageous amount (6721900), causing confusing among regular users about why it "costs" so much to claim or transfer. gasLimit should never exceed 100k, claiming is ~42k and transferring ONE is 21k