### PR TITLE
Fix loading avatar images by request by batch

### DIFF
--- a/appengine/src/services/sync/helpers.ts
+++ b/appengine/src/services/sync/helpers.ts
@@ -82,3 +82,23 @@ export const shuffle = (array: any[]) => {
 
     return array;
 }
+
+export async function processPromisesBatch(
+  items: Array<any>,
+  limit: number,
+  fn: (item: any) => Promise<any>,
+): Promise<any> {
+  let results = [];
+  for (let start = 0; start < items.length; start += limit) {
+    const end = start + limit > items.length ? items.length : start + limit;
+
+    const slicedResults = await Promise.all(items.slice(start, end).map(fn));
+
+    results = [
+      ...results,
+      ...slicedResults,
+    ]
+  }
+
+  return results;
+}

--- a/appengine/src/services/sync/validators-avatars.ts
+++ b/appengine/src/services/sync/validators-avatars.ts
@@ -1,4 +1,5 @@
 import {requestPromise} from "../../utils/requestPromise";
+import {processPromisesBatch} from './helpers';
 
 const CACHE_EXP_MS = 1000 * 60 * 60
 const LOOP_INTERVAL_MS = 1000 * 10 * 60
@@ -38,36 +39,28 @@ export class ValidatorsAvatarCacheService {
         return Boolean(cache && cache.keyBaseAvatar)
     }
 
+    cacheAvatar = async (v) => {
+        try {
+            const githubAvatar = await this.fetchGithubAvatarByValidatorAddress(v.address)
+            const keyBaseAvatar = await this.fetchKeyBaseAvatarByValidatorIdentity(v.identity)
+            this.cache.AVATAR_URLS[v.address] = {githubAvatar, keyBaseAvatar}
+            v.expirationTime = Date.now() + CACHE_EXP_MS
+        } catch (e) {
+            console.error(e)
+        }
+    }
+
     loop = async () => {
         try {
             const validators = (Object.values(this.cache.VALIDATORS) as any)
 
             // console.log(`Caching validators' avatars start`)
             const now = Date.now()
+            const filteredValidators = validators.filter(v => !(now < v.expirationTime && this.isCachedKeyBase(v.address)))
 
-            for (let v of validators) {
-                const {expirationTime} = v
+            await processPromisesBatch(filteredValidators, 50, this.cacheAvatar)
 
-                if (now < expirationTime && this.isCachedKeyBase(v.address)) {
-                    // todo disable cache
-                    continue
-                }
-
-                const cacheAvatar = async () => {
-                    try {
-                        const githubAvatar = await this.fetchGithubAvatarByValidatorAddress(v.address)
-                        const keyBaseAvatar = await this.fetchKeyBaseAvatarByValidatorIdentity(v.identity)
-                        this.cache.AVATAR_URLS[v.address] = {githubAvatar, keyBaseAvatar}
-                        v.expirationTime = Date.now() + CACHE_EXP_MS
-                    } catch (e) {
-                        console.error(e)
-                    }
-                }
-
-                // console.log('Caching avatar for', v.address)
-                cacheAvatar()
-            }
-            // console.log(`Caching validators' avatars end`, validators.length)
+            // console.log(`Caching validators' avatars end`, filteredValidators.length)
         } catch (e) {
             console.error(e)
         }
@@ -83,7 +76,7 @@ export class ValidatorsAvatarCacheService {
 
     fetchGithubAvatarByValidatorAddress = async (validatorAddress) => {
         const url = `https://github.com/harmony-one/validator-logos/raw/master/validators/${validatorAddress}.jpg`
-
+            
         try {
             return await requestPromise({url})
         } catch (e) {
@@ -92,8 +85,6 @@ export class ValidatorsAvatarCacheService {
     }
 
     fetchKeyBaseAvatarByValidatorIdentity = async (validatorIdentity) => {
-        const url = `https://keybase.io/_/api/1.0/user/lookup.json?key_fingerprint=${validatorIdentity}&fields=pictures`
-
         // const reqParams = {
         //     rejectUnauthorized: false,
         //     requestCert: false,//add when working with https sites
@@ -102,11 +93,24 @@ export class ValidatorsAvatarCacheService {
         // }
 
         try {
-            const keyBaseData = (await requestPromise({url})).toString() as any
-            const imgUrl = JSON.parse(keyBaseData).them[0].pictures.primary.url
-
-            return await requestPromise({url: imgUrl})
+            const url = 'https://keybase.io/_/api/1.0/user/lookup.json'
+            const qs = {
+                key_fingerprint: validatorIdentity,
+                fields: 'pictures',
+            }
+            const keyBaseData = (await requestPromise({url, qs})).toString() as any
+            const keyBaseDataJson = JSON.parse(keyBaseData)
+            
+            // if the status code is not 0, then there is an error or it doesn't exist
+            if (keyBaseDataJson.status.code !== 0) {
+                return null
+            }
+            
+            const imgUrl = keyBaseDataJson.them[0]?.pictures?.primary?.url
+            
+            return imgUrl ? await requestPromise({url: imgUrl}) : null
         } catch (e) {
+            console.error(`Error when fetching keybase image for ${validatorIdentity}`, e)
             return null
         }
     }


### PR DESCRIPTION
Too many http requests are done at the same time to get the avatar images, instead I do the same by batch of 50 so it is not too much. Also there were issues with special characters in the url for keybase, I passed the query string parameters in qs variable to fix that