### PR TITLE
[fix] - changed governance link from gov.harmony.one to snapshot.org

### DIFF
--- a/frontend/src/components/common/AppMenu.vue
+++ b/frontend/src/components/common/AppMenu.vue
@@ -156,7 +156,7 @@
       
       <a
         class="app-menu-item small"
-        href="https://governance.harmony.one/#/"
+        href="https://snapshot.org/#/harmony-mainnet.eth/"
         @click="close"
         target="_blank"
       >


### PR DESCRIPTION
Changed link to the new harmony mainnet eth