### PR TITLE
[fix] - change testnet dashboard link to explorer to the explorer.testnet.harmony.one

### DIFF
--- a/frontend/src/vuex/modules/connection.ts
+++ b/frontend/src/vuex/modules/connection.ts
@@ -123,7 +123,7 @@ export default ({ node }: { node: TNode }): Module<typeof state, any> => ({
         ...networkConfig,
         explorer_url:
             networkConfig.chain_title === 'testnet' ?
-                "https://explorer.pops.one":
+                "https://explorer.testnet.harmony.one":
                 networkConfig.explorer_url
       }
       state.network = networkConfig.id


### PR DESCRIPTION
Rn links in the testnet version are redirecting to the https://explorer.pops.one
I've checked the code and found this ternary operator and changed to the current testnet explorer