### PR TITLE
Update staking with new explorer links

### DIFF
--- a/frontend/src/components/staking/PageGlobal.vue
+++ b/frontend/src/components/staking/PageGlobal.vue
@@ -263,7 +263,7 @@ export default {
     },
     linkToTransaction() {
       const blocksUrl = this.networkConfig.explorer_url + "/block/"
-      return blocksUrl + this.networkInfo.current_block_hash
+      return blocksUrl + this.networkInfo.current_block_hash + "?shard=0"
     }
   },
   // watch: {

--- a/frontend/src/components/staking/PageGlobal.vue
+++ b/frontend/src/components/staking/PageGlobal.vue
@@ -263,7 +263,7 @@ export default {
     },
     linkToTransaction() {
       const blocksUrl = this.networkConfig.explorer_url + "/block/"
-      return blocksUrl + this.networkInfo.current_block_hash + "?shard=0"
+      return blocksUrl + this.networkInfo.current_block_number + "?shard=0"
     }
   },
   // watch: {

--- a/frontend/src/components/staking/PageValidatorCharts/DelegatorBlock.vue
+++ b/frontend/src/components/staking/PageValidatorCharts/DelegatorBlock.vue
@@ -18,13 +18,13 @@
         {{index + 1}}
       </div>
       <div class="address">
-        <a :href="`${networkConfig.explorer_url}/address/${delegator['delegator-address']}`" target="_blank">
+        <a :href="`${networkConfig.explorer_url}/address/${delegator['delegator-address']}?shard=0`" target="_blank">
           {{ delegator['delegator-address'] }}
         </a>
         {{validator_address === delegator['delegator-address'] ? '(self)' : ''}}
       </div>
       <div class="short-address">
-        <a :href="`${networkConfig.explorer_url}/address/${delegator['delegator-address']}`" target="_blank">
+        <a :href="`${networkConfig.explorer_url}/address/${delegator['delegator-address']}?shard=0`" target="_blank">
           {{ shortAddress(delegator['delegator-address']) }}
         </a>
         {{validator_address === delegator['delegator-address'] ? '(self)' : ''}}

--- a/frontend/src/components/staking/PageValidators/PageValidators.vue
+++ b/frontend/src/components/staking/PageValidators/PageValidators.vue
@@ -147,7 +147,7 @@ export default {
     },
     linkToTransaction() {
       const blocksUrl = this.networkConfig.explorer_url + "/block/"
-      return blocksUrl + this.networkInfo.current_block_hash
+      return blocksUrl + this.networkInfo.current_block_hash + "?shard=0"
     }
   },
   mounted() {

--- a/frontend/src/components/staking/PageValidators/PageValidators.vue
+++ b/frontend/src/components/staking/PageValidators/PageValidators.vue
@@ -147,7 +147,7 @@ export default {
     },
     linkToTransaction() {
       const blocksUrl = this.networkConfig.explorer_url + "/block/"
-      return blocksUrl + this.networkInfo.current_block_hash + "?shard=0"
+      return blocksUrl + this.networkInfo.current_block_number + "?shard=0"
     }
   },
   mounted() {


### PR DESCRIPTION
with the new blockscout explorer we need to update the links on the staking dashboard
- blocks info per hash is not available hence we using the block number : https://explorer.harmony.one/block/60039502?shard=0
- adding `?shard=0` so link points to data for account and block in shard 0 by default
