### PR TITLE
Removal Of Max Commission Change Per Day

### DIFF
--- a/frontend/src/components/staking/PageValidatorCharts/GeneralInfoBlock.vue
+++ b/frontend/src/components/staking/PageValidatorCharts/GeneralInfoBlock.vue
@@ -57,7 +57,7 @@
         </h4>
         <span>{{ validator.rate | percent | notAvailable }}</span>
       </li>
-      <li class="column">
+      <!-- <li class="column">
         <h4
           v-info-style
           v-tooltip.top="tooltips.v_profile.max_daily_change"
@@ -66,7 +66,7 @@
           Max Commission Change:&nbsp;
         </h4>
         <span>{{ validator.max_change_rate | percent | notAvailable }} (per day)</span>
-      </li>
+      </li> -->
       <li v-show="false" class="column">
         <h4 class="inline">Last Commission Change:&nbsp;</h4>
         <span>Block #{{ validator.update_height }}</span>


### PR DESCRIPTION
Since the Max Commission Change parameter cannot be modified on the blockchain and some validators mistakenly set it too high, it may be beneficial to remove this from the validator profile.

Future on chain ideas:
Change wont take affect for X days ( displayed on profile ) and to show it's going to change to X at epoch X.
-or-
Limit the changes to like 1 per year
-or-
Allow decreases to those statistics but block increasing. There should be no downside to being able to reduce this. 

For now , while the statistic remains active on-chain, its removal from the validator page could help remove any damaging impact from  validator progression. The current commission rate is the most critical statistic already present.